### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,9 +2,9 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
 
-  # def index
-  #   @items = Item.all
-  # end
+  def index
+    @items = Item.all
+  end
 
   # def show
   # end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
-    @items = Item.all
+    @items = Item.order(created_at: :desc)
   end
 
   # def show

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,6 +10,14 @@ class Item < ApplicationRecord
   has_one_attached :image
   # has_one :order
 
+  def image_url
+    image.attached? ? Rails.application.routes.url_helpers.url_for(image) : 'default_image_url.png'
+  end
+
+  def sold_out?
+    false
+  end
+
   validates :name, presence: true
   validates :description, presence: true
   validates :price, presence: true,

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,21 +128,21 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    
  <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to item_path(item) do %>
+            <%= link_to "#" do %>
               <div class='item-img-content'>
                <%= image_tag url_for(item.image), class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+         
                 <% if item.sold_out? %>
                   <div class='sold-out'>
                     <span>Sold Out!!</span>
                   </div>
                 <% end %>
-          <%# //商品が売れていればsold outを表示しましょう %>
+        
 
         </div>
         <div class='item-info'>
@@ -161,10 +161,7 @@
       </li>
       <% end %>
  <% else %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
         <li class='list'>
           <%= link_to '#' do %>
             <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -181,8 +178,7 @@
           <% end %>
         </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,24 +129,28 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+ <% if @items.present? %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to item_path(item) do %>
+              <div class='item-img-content'>
+               <%= image_tag url_for(item.image), class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+                <% if item.sold_out? %>
+                  <div class='sold-out'>
+                    <span>Sold Out!!</span>
+                  </div>
+                <% end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,27 +159,28 @@
         </div>
         <% end %>
       </li>
+      <% end %>
+ <% else %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>商品を出品してね！</h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,11 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+# config/environments/development.rb
+Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+
+# config/environments/production.rb
+Rails.application.routes.default_url_options[:host] = 'your_production_host.com'
+
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Item, type: :model do
     it 'is not valid without a user' do
       item = Item.new(user: nil)
       item.valid?
-      expect(item.errors.full_messages).to include("User must exist")
+      expect(item.errors.full_messages).to include('User must exist')
     end
 
     it 'is not valid without a name' do


### PR DESCRIPTION
### What
以下の通り商品一覧表示機能を実装しました。

1. 出品した商品が一覧表示されるようにする
2. 並び順を左上から新規登録されたものにする
3. 指示に基づき、適切な情報を、適切な形式で表示する

### Why
1. ユーザーに商品を見ることを可能とする。なお、新規ユーザー獲得のためにも、ログインしていないユーザーにも一覧表示を許可している。
2. UXの向上
3. UXの向上（指示に従い、ユーザーが求める情報をわかりやすく提示する）

### Gyazo

1. 商品のデータがない場合は、ダミー商品が表示されている動画
[https://gyazo.com/4cf3686b2221efc3f276aab2858baabb](url)
2. 商品のデータがある場合は、商品が一覧で表示されている動画
[https://gyazo.com/5f6854aab4e9123d998dc34b7c9c8071](url)
