### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
-  before_action :correct_user, only: [:edit, :update]
+  before_action :correct_user, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -34,10 +34,10 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def destroy
-  #   @item.destroy
-  #   redirect_to items_url, notice: 'Item was successfully destroyed.'
-  # end
+   def destroy
+     @item.destroy
+     redirect_to items_url, notice: 'Item was successfully destroyed.'
+   end
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
 
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: { turbo_method: :delete, confirm: "本当に削除しますか？" },  class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },  class:"item-destroy" %>
 
   <% elsif user_signed_in? %>
    <% unless @item.sold_out? %>


### PR DESCRIPTION
### What
以下の通り商品削除機能を実装しましたのでレビューをお願い致します。
1. destroyに関するアクションを設定し、（出品者のみが）商品削除を行えるようにする。
2. destroyアクションパスを設定し、削除ボタンを押すことで、当該アクションを実行可能とする。


### Why
誤った出品を行った際に適切に削除を行うことを可能とするため。

### Gyazo
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
[https://gyazo.com/10bc7ae603d0951730b8420400595707](url)